### PR TITLE
Fix correlation plotting when dataset count < 2

### DIFF
--- a/src/corr.py
+++ b/src/corr.py
@@ -118,6 +118,11 @@ def plot_correlation_matrices(datasets):
     """
     Genera y grafica las matrices de correlación para cada par de movimientos.
     """
+    # Si hay menos de dos datasets no tiene sentido generar las matrices
+    if len(datasets) < 2:
+        print("Se requieren al menos dos conjuntos de datos para calcular las matrices de correlación.")
+        return None
+
     num_pairs = len(datasets) * (len(datasets) - 1) // 2
     cols = 3  # Número de columnas en la matriz de subplots
     rows = (num_pairs + cols - 1) // cols  # Calcular filas necesarias
@@ -285,6 +290,8 @@ def main(data_folder='data'):
 
     # Generar y mostrar las matrices de correlación
     fig_corr_matrices = plot_correlation_matrices(datasets)
+    if fig_corr_matrices is None:
+        return
 
     # Calcular correlaciones promedio por punto clave
     avg_keypoint_corrs = compute_average_keypoint_correlations(datasets)


### PR DESCRIPTION
## Summary
- prevent correlation matrix plotting when fewer than two datasets are provided
- stop `corr.main` early if correlation matrices cannot be generated

## Testing
- `python -m py_compile main.py src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68491cb2d3e88331925d39d00f9a8c9f