### PR TITLE
Fix source handling in Tracking

### DIFF
--- a/src/tracking.py
+++ b/src/tracking.py
@@ -13,7 +13,10 @@ class Tracking:
         Inicializa el seguimiento en tiempo real.
         :param source: Fuente de video (0 para cámara de laptop, URL para cámara externa).
         """
-        self.source = int(source) if source.isdigit() else source
+        if isinstance(source, str) and source.isdigit():
+            self.source = int(source)
+        else:
+            self.source = source
         self.cap = None
         self.mp_drawing = mp.solutions.drawing_utils
         self.mp_pose = mp.solutions.pose

--- a/tests/test_tracking_constructor.py
+++ b/tests/test_tracking_constructor.py
@@ -1,0 +1,19 @@
+import unittest
+from src.tracking import Tracking
+
+class TestTrackingConstructor(unittest.TestCase):
+    def test_accepts_integer(self):
+        t = Tracking(source=0)
+        self.assertEqual(t.source, 0)
+
+    def test_accepts_string_digit(self):
+        t = Tracking(source='1')
+        self.assertEqual(t.source, 1)
+
+    def test_accepts_string_url(self):
+        url = 'http://example.com/video'
+        t = Tracking(source=url)
+        self.assertEqual(t.source, url)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure source parsing checks `isdigit()` only when `source` is a string
- add unit tests verifying constructor behavior with int and string values

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68491dfb15348331bd4cd81db26741e6