### PR TITLE
Add Dash dashboard for running modes

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -1,0 +1,104 @@
+import os
+import io
+import base64
+import threading
+
+import dash
+from dash import dcc, html
+from dash.dependencies import Input, Output, State
+import plotly.express as px
+import pandas as pd
+
+from src.tracking import Tracking
+from src.analysis import MovementAnalysis
+import corr
+
+app = dash.Dash(__name__)
+server = app.server
+
+app.layout = html.Div([
+    html.H2("Biomedical Workshops Dashboard"),
+    html.Div([
+        html.Label("Mode"),
+        dcc.Dropdown(
+            id='mode',
+            options=[
+                {'label': 'Tracking', 'value': 'track'},
+                {'label': 'Analyze', 'value': 'analyze'},
+                {'label': 'Correlation', 'value': 'corr'}
+            ],
+            value='track'
+        )
+    ], style={'width': '200px'}),
+    html.Div([
+        html.Label("Data folder"),
+        dcc.Input(id='data-folder', value='data', type='text')
+    ]),
+    html.Div([
+        html.Label("Frames"),
+        dcc.Input(id='frames', value='', type='number')
+    ]),
+    html.Button('Run', id='run-btn', n_clicks=0),
+    html.Div(id='output')
+])
+
+
+def run_tracking(source, max_frames):
+    tracker = Tracking(source=source)
+    tracker.run_analysis(max_frames=max_frames)
+
+def run_analyze(data_folder, max_frames):
+    analysis = MovementAnalysis(data_folder=data_folder, max_frames=max_frames)
+    analysis.run_analysis()
+
+def run_corr(data_folder, max_frames):
+    # Use functions directly to obtain matplotlib figures
+    datasets = corr.load_datasets(data_folder)
+    if not datasets:
+        return None
+    if max_frames is not None:
+        datasets = [(n, d.iloc[:max_frames]) for n, d in datasets]
+    datasets = corr.trim_datasets_to_smallest(datasets)
+    fig_corr = corr.plot_correlation_matrices(datasets)
+    avg = corr.compute_average_keypoint_correlations(datasets)
+    fig_heat = corr.plot_skeleton_heatmap(avg)
+    buf1 = io.BytesIO()
+    fig_corr.savefig(buf1, format='png')
+    buf1.seek(0)
+    buf2 = io.BytesIO()
+    fig_heat.savefig(buf2, format='png')
+    buf2.seek(0)
+    img1 = base64.b64encode(buf1.read()).decode('utf-8')
+    img2 = base64.b64encode(buf2.read()).decode('utf-8')
+    return img1, img2
+
+
+@app.callback(Output('output', 'children'),
+              Input('run-btn', 'n_clicks'),
+              State('mode', 'value'),
+              State('data-folder', 'value'),
+              State('frames', 'value'))
+def run_action(n_clicks, mode, data_folder, frames):
+    if n_clicks == 0:
+        return ''
+    max_frames = int(frames) if frames not in (None, '', 'None') else None
+    if mode == 'track':
+        threading.Thread(target=run_tracking, args=('0', max_frames)).start()
+        return html.Div('Running tracking... Check the opened window to stop.')
+    elif mode == 'analyze':
+        threading.Thread(target=run_analyze, args=(data_folder, max_frames)).start()
+        return html.Div('Running analysis... check console for results.')
+    else:
+        result = run_corr(data_folder, max_frames)
+        if result is None:
+            return html.Div('No datasets found.')
+        img1, img2 = result
+        return html.Div([
+            html.Img(src='data:image/png;base64,{}'.format(img1)),
+            html.Br(),
+            html.Img(src='data:image/png;base64,{}'.format(img2))
+        ])
+
+
+if __name__ == '__main__':
+    app.run_server(debug=False)

--- a/main.py
+++ b/main.py
@@ -39,19 +39,21 @@ def main():
                         help='Fuente de video: 0 para cámara de laptop, URL para cámara externa (solo en modo "track")')
     parser.add_argument('--data_folder', type=str, default='data',
                         help='Carpeta donde se almacenan los archivos CSV de datos (solo en modos "analyze" y "corr")')
+    parser.add_argument('--frames', type=int, default=None,
+                        help='Número máximo de frames a analizar o grabar')
     args = parser.parse_args()
 
     if args.mode == 'track':
         # Ejecutar el código de tracking
         tracking = Tracking(source=args.source)
-        tracking.run_analysis()
+        tracking.run_analysis(max_frames=args.frames)
     elif args.mode == 'analyze':
         # Ejecutar el código de análisis
-        analysis = MovementAnalysis(data_folder=args.data_folder)
+        analysis = MovementAnalysis(data_folder=args.data_folder, max_frames=args.frames)
         analysis.run_analysis()
     elif args.mode == 'corr':
         # Ejecutar el código de correlación utilizando corr.py
-        corr.main(data_folder=args.data_folder)
+        corr.main(data_folder=args.data_folder, max_frames=args.frames)
     else:
         print('Modo no reconocido. Usa "track", "analyze" o "corr".')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ opencv-python
 numpy
 pandas
 matplotlib
+dash

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -8,11 +8,12 @@ import matplotlib.animation as animation
 import pandas as pd
 
 class MovementAnalysis:
-    def __init__(self, data_folder='data'):
+    def __init__(self, data_folder='data', max_frames=None):
         """
         Inicializa la clase para el análisis de movimientos.
         """
         self.data_folder = data_folder
+        self.max_frames = max_frames
         self.datasets = []
         self.load_datasets()
 
@@ -34,6 +35,8 @@ class MovementAnalysis:
         for file in csv_files:
             data = self.load_data_from_csv(file)
             if data is not None:
+                if self.max_frames is not None:
+                    data = data.iloc[:self.max_frames]
                 basename = os.path.basename(file)
                 # Corregimos el orden de las condiciones
                 if 'INVALIDO' in basename:

--- a/src/corr.py
+++ b/src/corr.py
@@ -279,11 +279,14 @@ def plot_skeleton_heatmap(avg_keypoint_corrs):
     # plt.show()  # No mostrar aún para poder mostrar ambas figuras al mismo tiempo
     return fig  # Retornar la figura
 
-def main(data_folder='data'):
+def main(data_folder='data', max_frames=None):
     global datasets  # Hacer datasets global para usar en otras funciones
     datasets = load_datasets(data_folder)
     if not datasets:
         return
+
+    if max_frames is not None:
+        datasets = [(name, data.iloc[:max_frames]) for name, data in datasets]
 
     # Recortar los conjuntos de datos al tamaño del archivo más pequeño
     datasets = trim_datasets_to_smallest(datasets)

--- a/src/tracking.py
+++ b/src/tracking.py
@@ -32,7 +32,7 @@ class Tracking:
         self.movement_label = None
         self.arm_raised_start_time = None
 
-    def run_analysis(self):
+    def run_analysis(self, max_frames=None):
         """
         Realiza el seguimiento en tiempo real.
         """
@@ -42,6 +42,7 @@ class Tracking:
                 raise ValueError("Error al abrir la fuente de video")
 
             with self.mp_pose.Pose(min_detection_confidence=0.6, min_tracking_confidence=0.6) as pose:
+                frame_count = 0
                 while self.cap.isOpened():
                     ret, frame = self.cap.read()
                     if not ret:
@@ -140,6 +141,10 @@ class Tracking:
 
                     key = cv2.waitKey(1) & 0xFF
                     if key == ord('q'):
+                        break
+
+                    frame_count += 1
+                    if max_frames is not None and frame_count >= max_frames:
                         break
 
         except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- allow specifying maximum frames via `--frames`
- support optional frame limit in tracking, analysis, and correlation modules
- add Dash dashboard to choose mode and display results
- include dash in requirements and make src a package

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491f771dec83318c8c54cd7b9a969b